### PR TITLE
explicitly require the CJS version of remove-array-items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 npm-debug.log*
 .DS_Store
 .nyc_output
+
+remove_array_items_test.js

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,4 +1,4 @@
-var removeItems = require('remove-array-items')
+var removeItems = require('remove-array-items/dist/remove-array-items.cjs')
 var scheduler = require('nanoscheduler')()
 var nanologger = require('nanologger')
 var _log = nanologger('choo')

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "choo-devtools",
+  "name": "@showrunner/choo-devtools",
   "description": "Console devtools for Choo",
   "repository": "choojs/choo-devtools",
-  "version": "3.0.4",
+  "version": "4.0.0",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "start": "node .",
@@ -17,7 +17,7 @@
     "on-performance": "^1.2.1",
     "plucker": "0.0.0",
     "prettier-bytes": "^1.0.4",
-    "remove-array-items": "^2.0.0",
+    "remove-array-items": "2.0.1",
     "state-copy": "^1.0.5",
     "wayfarer": "^7.0.0"
   },


### PR DESCRIPTION
turns out its not a version mismatch that's causing the error @uooq noticed. our own web ESM refactor (or webpack or craco) must be signalling to choo-devtools that its okay to import remove-array-items in ESM form instead of trusty ol' CJS.

publishing this tweak and consuming it in wallaby would solve the problem, but its brittle as hell. we could also try and land a real fix upstream or figure out whether our own bundler will allow choo-devtools to live in the past.

on the flipside, it hardly seems worth it to waste time looking at our navels 🤷 

[sc-403]